### PR TITLE
Eng 932 support db password reset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.1.6</version>
+        <version>6.1.8</version>
     </parent>
     <version>6.1.0-SNAPSHOT</version>
     <artifactId>entando-k8s-keycloak-controller</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando.k8s.operator.common.version>6.1.4</entando.k8s.operator.common.version>
-        <entando.k8s.custom.model.version>6.1.4</entando.k8s.custom.model.version>
+        <entando.k8s.operator.common.version>6.1.11</entando.k8s.operator.common.version>
+        <entando.k8s.custom.model.version>6.1.5</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>in-process</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>
     </properties>

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerBaseIT.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerBaseIT.java
@@ -64,17 +64,6 @@ public abstract class AddEntandoKeycloakServerBaseIT implements FluentIntegratio
         System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_NAMESPACE_TO_OBSERVE.getJvmSystemProperty(),
                 TestFixturePreparation.ENTANDO_CONTROLLERS_NAMESPACE);
         client = helper.getClient();
-        clearNamespace();
-        await().atMost(2, TimeUnit.MINUTES).ignoreExceptions().pollInterval(10, TimeUnit.SECONDS).until(this::killPgPod);
-        EntandoKeycloakServerController controller = new EntandoKeycloakServerController(client, false);
-        if (EntandoOperatorTestConfig.getTestTarget() == TestTarget.K8S) {
-            helper.keycloak().listenAndRespondWithImageVersionUnderTest(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE);
-        } else {
-            helper.keycloak().listenAndRespondWithStartupEvent(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE, controller::onStartup);
-        }
-    }
-
-    protected void clearNamespace() {
         //Reset all namespaces as they depend on previously created Keycloak clients that are now invalid
         helper.setTextFixture(deleteAll(EntandoKeycloakServer.class)
                 .fromNamespace(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE)
@@ -87,6 +76,13 @@ public abstract class AddEntandoKeycloakServerBaseIT implements FluentIntegratio
                 .deleteAll(EntandoPlugin.class)
                 .fromNamespace(EntandoPluginIntegrationTestHelper.TEST_PLUGIN_NAMESPACE)
         );
+        await().atMost(2, TimeUnit.MINUTES).ignoreExceptions().pollInterval(10, TimeUnit.SECONDS).until(this::killPgPod);
+        EntandoKeycloakServerController controller = new EntandoKeycloakServerController(client, false);
+        if (EntandoOperatorTestConfig.getTestTarget() == TestTarget.K8S) {
+            helper.keycloak().listenAndRespondWithImageVersionUnderTest(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE);
+        } else {
+            helper.keycloak().listenAndRespondWithStartupEvent(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE, controller::onStartup);
+        }
     }
 
     private boolean killPgPod() {

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerBaseIT.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerBaseIT.java
@@ -63,6 +63,18 @@ public abstract class AddEntandoKeycloakServerBaseIT implements FluentIntegratio
     public void cleanup() {
         System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_NAMESPACE_TO_OBSERVE.getJvmSystemProperty(),
                 TestFixturePreparation.ENTANDO_CONTROLLERS_NAMESPACE);
+        client = helper.getClient();
+        clearNamespace();
+        await().atMost(2, TimeUnit.MINUTES).ignoreExceptions().pollInterval(10, TimeUnit.SECONDS).until(this::killPgPod);
+        EntandoKeycloakServerController controller = new EntandoKeycloakServerController(client, false);
+        if (EntandoOperatorTestConfig.getTestTarget() == TestTarget.K8S) {
+            helper.keycloak().listenAndRespondWithImageVersionUnderTest(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE);
+        } else {
+            helper.keycloak().listenAndRespondWithStartupEvent(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE, controller::onStartup);
+        }
+    }
+
+    protected void clearNamespace() {
         //Reset all namespaces as they depend on previously created Keycloak clients that are now invalid
         helper.setTextFixture(deleteAll(EntandoKeycloakServer.class)
                 .fromNamespace(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE)
@@ -75,14 +87,6 @@ public abstract class AddEntandoKeycloakServerBaseIT implements FluentIntegratio
                 .deleteAll(EntandoPlugin.class)
                 .fromNamespace(EntandoPluginIntegrationTestHelper.TEST_PLUGIN_NAMESPACE)
         );
-        client = helper.getClient();
-        await().atMost(2, TimeUnit.MINUTES).ignoreExceptions().pollInterval(10, TimeUnit.SECONDS).until(this::killPgPod);
-        EntandoKeycloakServerController controller = new EntandoKeycloakServerController(client, false);
-        if (EntandoOperatorTestConfig.getTestTarget() == TestTarget.K8S) {
-            helper.keycloak().listenAndRespondWithImageVersionUnderTest(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE);
-        } else {
-            helper.keycloak().listenAndRespondWithStartupEvent(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE, controller::onStartup);
-        }
     }
 
     private boolean killPgPod() {

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
@@ -55,11 +55,10 @@ public class AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT extends Ad
         assertThat(client.apps().deployments().inNamespace(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE).withName(
                 KeycloakIntegrationTestHelper.KEYCLOAK_NAME + "-db-deployment")
                 .get(), Matchers.is(nullValue()));
-        //And recreating the deployment still succeeds because it regenerates all passwords
+        //And recreating the deployment still succeeds because it regenerates all passwords for database schemas
         clearNamespace();
         System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_FORCE_DB_PASSWORD_RESET.getJvmSystemProperty(), "true");
         helper.keycloak().createAndWaitForKeycloak(keycloakServer, 0, false);
-        //Then I expect to see
         verifyKeycloakDeployment();
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
@@ -20,11 +20,13 @@ import static org.entando.kubernetes.model.DbmsVendor.POSTGRESQL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 
+import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
 import org.entando.kubernetes.controller.integrationtest.support.KeycloakIntegrationTestHelper;
 import org.entando.kubernetes.controller.integrationtest.support.SampleWriter;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServer;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServerBuilder;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
@@ -55,8 +57,17 @@ public class AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT extends Ad
                 .get(), Matchers.is(nullValue()));
         //And recreating the deployment still succeeds because it regenerates all passwords
         clearNamespace();
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_FORCE_DB_PASSWORD_RESET.getJvmSystemProperty(), "true");
         helper.keycloak().createAndWaitForKeycloak(keycloakServer, 0, false);
         //Then I expect to see
         verifyKeycloakDeployment();
+    }
+
+    @Override
+    @AfterEach
+    public void afterwards() {
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_FORCE_DB_PASSWORD_RESET.getJvmSystemProperty());
+        super.afterwards();
+
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
@@ -48,10 +48,15 @@ public class AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT extends Ad
                 .endSpec().build();
         SampleWriter.writeSample(keycloakServer, "keycloak-with-external-postgresql-db");
         helper.keycloak().createAndWaitForKeycloak(keycloakServer, 0, false);
-        //Then I expect to see
+        //Then I expect to see a valid keycloak deployment
         verifyKeycloakDeployment();
         assertThat(client.apps().deployments().inNamespace(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE).withName(
                 KeycloakIntegrationTestHelper.KEYCLOAK_NAME + "-db-deployment")
                 .get(), Matchers.is(nullValue()));
+        //And recreating the deployment still succeeds because it regenerates all passwords
+        clearNamespace();
+        helper.keycloak().createAndWaitForKeycloak(keycloakServer, 0, false);
+        //Then I expect to see
+        verifyKeycloakDeployment();
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/interprocesstests/AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT.java
@@ -21,10 +21,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 
 import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
+import org.entando.kubernetes.controller.integrationtest.support.ClusterInfrastructureIntegrationTestHelper;
+import org.entando.kubernetes.controller.integrationtest.support.EntandoAppIntegrationTestHelper;
+import org.entando.kubernetes.controller.integrationtest.support.EntandoPluginIntegrationTestHelper;
 import org.entando.kubernetes.controller.integrationtest.support.KeycloakIntegrationTestHelper;
 import org.entando.kubernetes.controller.integrationtest.support.SampleWriter;
+import org.entando.kubernetes.model.app.EntandoApp;
+import org.entando.kubernetes.model.externaldatabase.EntandoDatabaseService;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServer;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServerBuilder;
+import org.entando.kubernetes.model.plugin.EntandoPlugin;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -56,7 +63,9 @@ public class AddEntandoKeycloakServerWithExternalPostgresqlDatabaseIT extends Ad
                 KeycloakIntegrationTestHelper.KEYCLOAK_NAME + "-db-deployment")
                 .get(), Matchers.is(nullValue()));
         //And recreating the deployment still succeeds because it regenerates all passwords for database schemas
-        clearNamespace();
+        //Reset all namespaces as they depend on previously created Keycloak clients that are now invalid
+        helper.setTextFixture(deleteAll(EntandoKeycloakServer.class)
+                .fromNamespace(KeycloakIntegrationTestHelper.KEYCLOAK_NAMESPACE));
         System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_FORCE_DB_PASSWORD_RESET.getJvmSystemProperty(), "true");
         helper.keycloak().createAndWaitForKeycloak(keycloakServer, 0, false);
         verifyKeycloakDeployment();


### PR DESCRIPTION
Bumps the entando-k8s-operator-common dependency to the latest version and added a test step to verify that we can recreate a EntandoKeycloakServer against the same database once the original EntandoKeycloakServer and its Secrets have been deleted