### PR TITLE
ENG-3480 use networking.k8s.io/v1 api group instead of extensions/v1b…

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM entando/entando-k8s-operator-common:7.0.0-ENG-3500-PR-98
+FROM entando/entando-k8s-operator-common:7.0.1-ENG-3480-PR-96
 
 ARG VERSION
 LABEL name="Entando K8S Keycloak Controller" \

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <version>7.0.0</version>
         <relativePath/>
     </parent>
-    <version>7.0.0</version>
+    <version>7.0.1</version>
     <artifactId>entando-k8s-keycloak-controller</artifactId>
     <name>Entando K8S Controller for Keycloak</name>
     <description>Entando's K8S Controller for Keycloak</description>
@@ -64,7 +64,7 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando-k8s-operator-common.version>7.0.0-ENG-3500-PR-98</entando-k8s-operator-common.version>
+        <entando-k8s-operator-common.version>7.0.1-ENG-3480-PR-96</entando-k8s-operator-common.version>
         <skipLicenseDownload>true</skipLicenseDownload>
         <preDeploymentTestGroups>in-process</preDeploymentTestGroups>
         <postDeploymentTestGroups>smoke</postDeploymentTestGroups>

--- a/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakDeployable.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakDeploymentResult.java
+++ b/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakDeploymentResult.java
@@ -18,7 +18,7 @@ package org.entando.kubernetes.controller.keycloakserver;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import org.entando.kubernetes.controller.spi.container.ProvidedSsoCapability;
 import org.entando.kubernetes.controller.spi.result.ExposedDeploymentResult;
 import org.entando.kubernetes.model.common.ServerStatus;

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/DeployedKeycloakCapabilityTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/DeployedKeycloakCapabilityTest.java
@@ -29,7 +29,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.qameta.allure.Allure;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/DeployedKeycloakServerTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/DeployedKeycloakServerTest.java
@@ -46,7 +46,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.qameta.allure.Allure;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;


### PR DESCRIPTION
…eta1 for the created ingresses