### PR TITLE
ENG-3515 use networking.k8s.io/v1 api group instead of extensions/v1b…

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,5 +1,5 @@
 #FROM entando/entando-ubi8-java11-base:6.3.0
-FROM entando/entando-k8s-operator-common:6.3.19
+FROM entando/entando-k8s-operator-common:6.5.0-ENG-3515-PR-104
 
 ARG VERSION
 LABEL name="Entando K8S Keycloak Controller" \

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.3.18</version>
+        <version>6.5.0-ENG-3515-PR-26</version>
         <relativePath/>
     </parent>
     <version>6.5.0</version>
@@ -64,7 +64,7 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando-k8s-operator-common.version>6.3.19</entando-k8s-operator-common.version>
+        <entando-k8s-operator-common.version>6.5.0-ENG-3515-PR-104</entando-k8s-operator-common.version>
         <skipLicenseDownload>true</skipLicenseDownload>
         <preDeploymentTestGroups>pre-deployment</preDeploymentTestGroups>
         <postDeploymentTestGroups>post-deployment</postDeploymentTestGroups>

--- a/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakDeployable.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakServiceDeploymentResult.java
+++ b/src/main/java/org/entando/kubernetes/controller/keycloakserver/KeycloakServiceDeploymentResult.java
@@ -18,7 +18,7 @@ package org.entando.kubernetes.controller.keycloakserver;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import org.entando.kubernetes.controller.spi.result.ExposedDeploymentResult;
 
 public class KeycloakServiceDeploymentResult extends ExposedDeploymentResult<KeycloakServiceDeploymentResult> {

--- a/src/test/java/org/entando/kubernetes/controller/keycloakserver/inprocesstests/DeployKeycloakServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/keycloakserver/inprocesstests/DeployKeycloakServiceTest.java
@@ -42,8 +42,8 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceStatus;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
-import io.fabric8.kubernetes.api.model.extensions.IngressStatus;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressStatus;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.quarkus.runtime.StartupEvent;
 import java.io.IOException;
@@ -329,8 +329,8 @@ class DeployKeycloakServiceTest implements InProcessTestUtil, FluentTraversals, 
         verify(client.ingresses()).createIngress(eq(newEntandoKeycloakServer), ingressArgumentCaptor.capture());
         Ingress resultingIngress = ingressArgumentCaptor.getValue();
         //With a path that reflects webcontext of Keycloak, mapped to the previously created service
-        assertThat(theBackendFor(AUTH).on(resultingIngress).getServicePort().getIntVal(), is(8080));
-        assertThat(theBackendFor(AUTH).on(resultingIngress).getServiceName(), is(MY_KEYCLOAK_SERVER_SERVICE));
+        assertThat(theBackendFor(AUTH).on(resultingIngress).getService().getPort().getNumber(), is(8080));
+        assertThat(theBackendFor(AUTH).on(resultingIngress).getService().getName(), is(MY_KEYCLOAK_SERVER_SERVICE));
         //And the Ingress state was reloaded from K8S
         verify(client.ingresses(), times(2))
                 .loadIngress(eq(newEntandoKeycloakServer.getMetadata().getNamespace()), eq(MY_KEYCLOAK_INGRESS));
@@ -585,7 +585,7 @@ class DeployKeycloakServiceTest implements InProcessTestUtil, FluentTraversals, 
         //And that K8S is up and receiving PVC requests
         PersistentVolumeClaimStatus dbPvcStatus = new PersistentVolumeClaimStatus();
         lenient().when(client.persistentVolumeClaims()
-                .loadPersistentVolumeClaim(eq(newEntandoKeycloakServer), eq(MY_KEYCLOAK_DB_PVC)))
+                        .loadPersistentVolumeClaim(eq(newEntandoKeycloakServer), eq(MY_KEYCLOAK_DB_PVC)))
                 .then(respondWithPersistentVolumeClaimStatus(dbPvcStatus));
 
         //When the KeycloakController is notified that a new EntandoKeycloakServer has been added


### PR DESCRIPTION
…eta1 for the created ingresses